### PR TITLE
Get bus lines serving particular stop IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,24 @@ This application is not deployed yet. To run it locally, you must [request a Bus
 export MTA_BUSTIME_KEY='[your key here]'
 ```
 
+## Current functionality:
+At /location, user enters an address and clicks getLatLon.
+
+Application console logs the following:
+* Latitude and longitude for that address
+* MTA bus stops within 200 meters of that latitude & longitude
+* Bus routes serving the first bus stop in the array 
+
+### TBD:
+
+* Console log ALL bus routes serving ALL bus stops in the array
+
+* for each route/line (or stop?), need to make separate call to get nearby buses. 
+
+** _example by stop:_
+http://bustime.mta.info/api/siri/stop-monitoring.json?key=[key]&OperatorRef=MTA&MonitoringRef=400324
+
+** _example by line:_
+http://bustime.mta.info/api/siri/vehicle-monitoring.json?&VehicleRef=339&key=[key]&OperatorRef=MTA
+
+

--- a/browser/location.js
+++ b/browser/location.js
@@ -27,6 +27,7 @@ app.factory('GeoFactory', function ($http) {
 		geocoder = new google.maps.Geocoder(),
 		GeoFactory = {},
 		myLatLon = {};
+		
 
 	GeoFactory.getLatLon = function(address) {
 		geocoder.geocode( { 'address': address}, function(results, status) {
@@ -43,11 +44,26 @@ app.factory('GeoFactory', function ($http) {
 	}
 
 	GeoFactory.getStops = function(latLon) {
+		console.log("GeoFactory getStops on", latLon);
 		return $http.get('/api/stops', {params: latLon})
 		.then(function (response) {
-			console.log("successful response", response.data)
+			console.log("successful response", response.data);
+			GeoFactory.getLines(response.data)
 			}, function(err) {
 				console.error("Error:",err)
+		})
+	};
+
+	GeoFactory.getLines = function(stopArray) {
+		console.log("GeoFactory getLines on", stopArray)
+
+		return $http.get('/api/lines', {
+			params: {stop: stopArray[0]}
+		})
+		.then(function(response) {
+			console.log("successful response", response.data)
+		}, function (err) {
+			console.error("Error:", err)
 		})
 	}
 

--- a/sample-data/lines.json
+++ b/sample-data/lines.json
@@ -1,0 +1,15 @@
+// http://bustime.mta.info/api/where/stop/MTA_302219.json?key=KEY
+data.routes[0].id
+
+
+{"code":200,"currentTime":1464191638643,
+
+"data":{"code":"302219","direction":"NE","id":"MTA_302219","lat":40.639883,"locationType":0,"lon":-73.967187,"name":"CORTELYOU RD / WESTMINSTER RD",
+
+"routes":[
+{"agency":{"disclaimer":"","id":"MTABC","lang":"EN","name":"MTA Bus Company","phone":"","privateService":false,"timezone":"America/New_York","url":"http://www.mta.info"}
+,"color":"FAA61A","description":"","id":"MTABC_B103","longName":"Canarsie - Downtown Brooklyn Ltd","shortName":"B103","textColor":"FFFFFF","type":3,"url":"http://web.mta.info/busco/schedules/b103cur.pdf"},
+{"agency":{"disclaimer":"","id":"MTABC","lang":"EN","name":"MTA Bus Company","phone":"","privateService":false,"timezone":"America/New_York","url":"http://www.mta.info"},"color":"00933C","description":"Via Cortelyou Rd / Ave K / E 66Th St","id":"MTABC_BM1","longName":"Mill Basin - Downtown/Midtown","shortName":"BM1","textColor":"FFFFFF","type":3,"url":"http://web.mta.info/busco/schedules/bm001cur.pdf"},
+{"agency":{"disclaimer":"","id":"MTABC","lang":"EN","name":"MTA Bus Company","phone":"","privateService":false,"timezone":"America/New_York","url":"http://www.mta.info"},"color":"00933C","description":"","id":"MTABC_BM2","longName":"Canarsie/Spring Creek - Downtown/Midtown","shortName":"BM2","textColor":"FFFFFF","type":3,"url":"http://web.mta.info/busco/schedules/bm002cur.pdf"},
+{"agency":{"disclaimer":"","id":"MTABC","lang":"EN","name":"MTA Bus Company","phone":"","privateService":false,"timezone":"America/New_York","url":"http://www.mta.info"},"color":"00933C","description":"Via Emmons Av / Ocean Av / Cortelyou Rd","id":"MTABC_BM3","longName":"Sheepshead Bay - Downtown/Midtown","shortName":"BM3","textColor":"FFFFFF","type":3,"url":"http://web.mta.info/busco/schedules/bm003cur.pdf"},
+{"agency":{"disclaimer":"","id":"MTABC","lang":"EN","name":"MTA Bus Company","phone":"","privateService":false,"timezone":"America/New_York","url":"http://www.mta.info"},"color":"00933C","description":"Via Gerritsen Av / Nostrand Av / Ocean Av","id":"MTABC_BM4","longName":"Gerritsen Beach - Downtown/Midtown","shortName":"BM4","textColor":"FFFFFF","type":3,"url":"http://web.mta.info/busco/schedules/bm004cur.pdf"}],"wheelchairBoarding":"UNKNOWN"},"text":"OK","version":1}

--- a/sample-data/vehicle-monitoring.json
+++ b/sample-data/vehicle-monitoring.json
@@ -1,0 +1,1 @@
+{"Siri":{"ServiceDelivery":{"ResponseTimestamp":"2016-05-25T14:45:43.481-04:00","VehicleMonitoringDelivery":[{"VehicleActivity":[],"ResponseTimestamp":"2016-05-25T14:45:43.481-04:00","ValidUntil":"2016-05-25T14:46:43.481-04:00"}],"SituationExchangeDelivery":[]}}}


### PR DESCRIPTION
### Added new sample data:

  sample-data/lines.json
### Built out /api/lines and /api/stops routes.
- /api/stops gets all stops within 200 meters of the entered lat/lon
- /api/lines is intended to get all bus routes (e.g. B103) near a particular stop. Right now, it's picking out the first stop in a long array, and returning the routes available for that stop. This information is sent to the browser via res.json and also console logged.
